### PR TITLE
Workaround for non Valo theme issue

### DIFF
--- a/vaadin-context-menu-addon/pom.xml
+++ b/vaadin-context-menu-addon/pom.xml
@@ -5,12 +5,12 @@
     <groupId>com.vaadin.addon</groupId>
     <artifactId>vaadin-context-menu</artifactId>
     <packaging>jar</packaging>
-    <version>0.7</version>
+    <version>0.8-SNAPSHOT</version>
     <name>Vaadin ContextMenu</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.6-SNAPSHOT</vaadin.version>
+        <vaadin.version>7.7.0</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
         <!-- ZIP Manifest fields -->

--- a/vaadin-context-menu-addon/src/main/java/com/vaadin/addon/contextmenu/client/ContextMenuConnector.java
+++ b/vaadin-context-menu-addon/src/main/java/com/vaadin/addon/contextmenu/client/ContextMenuConnector.java
@@ -168,6 +168,7 @@ public class ContextMenuConnector extends AbstractExtensionConnector {
 	}
 
 	private void showMenu(int eventX, int eventY) {
+                dummyRootMenuBar.setSelected(dummyRootMenuBar.getItems().get(0));
 		dummyRootMenuBar.showChildMenuAt(dummyRootMenuBar.getItems().get(0),
 				eventY, eventX);
 	}

--- a/vaadin-context-menu-addon/src/main/java/com/vaadin/addon/contextmenu/client/MyVMenuBar.java
+++ b/vaadin-context-menu-addon/src/main/java/com/vaadin/addon/contextmenu/client/MyVMenuBar.java
@@ -287,6 +287,33 @@ public class MyVMenuBar extends VMenuBar {
 		subMenu.selectFirstItem();
 
 	}
+	
+	@Override
+	public void itemClick(CustomMenuItem item) {
+        if (item.getCommand() != null) {
+        	try {
+            	item.getCommand().execute();
+        	} finally {
+                setSelected(null);
+                if (visibleChildMenu != null) {
+                    visibleChildMenu.hideChildren();
+                }
+                hideParents(true);
+                menuVisible = false;
+        	}
+        } else {
+            if (item.getSubMenu() != null
+                    && item.getSubMenu() != visibleChildMenu) {
+                setSelected(item);
+                showChildMenu(item);
+                menuVisible = true;
+            } else if (!subMenu) {
+                setSelected(null);
+                hideChildren();
+                menuVisible = false;
+            }
+        }
+	}
 
 	public boolean isPopupShowing() {
 		return menuVisible;

--- a/vaadin-context-menu-demo/pom.xml
+++ b/vaadin-context-menu-demo/pom.xml
@@ -5,13 +5,13 @@
     <groupId>com.vaadin.addon</groupId>
     <artifactId>vaadin-context-menu-demo</artifactId>
     <packaging>war</packaging>
-    <version>0.7</version>
+    <version>0.8-SNAPSHOT</version>
     <name>Vaadin ContextMenu Demo</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.6-SNAPSHOT</vaadin.version>
-        <vaadin.plugin.version>7.5.7</vaadin.plugin.version>
+        <vaadin.version>7.7.0</vaadin.version>
+        <vaadin.plugin.version>7.7.0</vaadin.plugin.version>
     </properties>
 
     <organization>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.vaadin.addon</groupId>
             <artifactId>vaadin-context-menu</artifactId>
-            <version>${project.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Same fix as in https://dev.vaadin.com/review/13912, but only for ContextMenu add-on. Also contains fix for critical 7.7 compatibility issue.

closes #27 & #26 & #31

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/context-menu/30)
<!-- Reviewable:end -->
