### PR TITLE
Fix Table and TreeTable with ItemClickListener

### DIFF
--- a/vaadin-context-menu-demo/pom.xml
+++ b/vaadin-context-menu-demo/pom.xml
@@ -10,8 +10,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.7.0</vaadin.version>
+        <vaadin.version>7.7.7</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
+        <jetty.plugin.version>9.3.9.v20160517</jetty.plugin.version>
     </properties>
 
     <organization>
@@ -184,16 +185,12 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>8.1.16.v20140903</version>
+                <version>${jetty.plugin.version}</version>
                 <configuration>
-                    <webApp>
-                        <contextPath>/context-menu</contextPath>
-                    </webApp>
-                    <scanIntervalSeconds>5</scanIntervalSeconds>
+                    <scanIntervalSeconds>3</scanIntervalSeconds>
                 </configuration>
             </plugin>
 

--- a/vaadin-context-menu-demo/src/main/java/com/vaadin/addon/contextmenu/ContextMenuTreeTable.java
+++ b/vaadin-context-menu-demo/src/main/java/com/vaadin/addon/contextmenu/ContextMenuTreeTable.java
@@ -1,0 +1,118 @@
+package com.vaadin.addon.contextmenu;
+
+import java.util.EventObject;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.addon.contextmenu.ContextMenu;
+import com.vaadin.addon.contextmenu.ContextMenu.ContextMenuOpenListener;
+import com.vaadin.addon.contextmenu.ContextMenu.ContextMenuOpenListener.ContextMenuOpenEvent;
+import com.vaadin.annotations.Theme;
+import com.vaadin.annotations.VaadinServletConfiguration;
+import com.vaadin.data.Item;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinServlet;
+import com.vaadin.shared.MouseEventDetails.MouseButton;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.TreeTable;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.ui.HorizontalLayout;
+
+/**
+ * For testing workaround for #29. Open with ../context-menu/?treetable
+ */
+public class ContextMenuTreeTable extends VerticalLayout {
+
+    private ContextMenu menu;
+    private TreeTable table;
+    private VerticalLayout logLayout;
+    private int counter;
+
+    public ContextMenuTreeTable() {
+        createTreeTable();
+        logLayout = new VerticalLayout();
+        Panel logPanel = new Panel();
+        logPanel.setContent(logLayout);
+        logPanel.setHeight("100px");
+
+        HorizontalLayout buttons = new HorizontalLayout();
+        buttons.addComponent(new Button("Add ItemClickListener to TreeTable",
+                new Button.ClickListener() {
+
+                    @Override
+                    public void buttonClick(ClickEvent event) {
+                        addItemClickListener(table);
+                    }
+                }));
+        buttons.addComponent(new Button("Add ContextMenu to TreeTable",
+                new Button.ClickListener() {
+
+                    @Override
+                    public void buttonClick(ClickEvent event) {
+                        addContextMenu(table);
+                    }
+                }));
+        buttons.addComponent(new Button("Add ContextMenuOpenListener to Menu",
+                new Button.ClickListener() {
+
+                    @Override
+                    public void buttonClick(ClickEvent event) {
+                        menu.addContextMenuOpenListener(
+                                new ContextMenuOpenListener() {
+
+                                    @Override
+                                    public void onContextMenuOpen(
+                                            ContextMenuOpenEvent event) {
+                                        log(event, "");
+                                    }
+                                });
+                    }
+                }));
+
+        setMargin(true);
+        setSpacing(true);
+        addComponents(logPanel, buttons, table);
+    }
+
+    @SuppressWarnings("unchecked")
+    private TreeTable createTreeTable() {
+        table = new TreeTable();
+        table.addContainerProperty("id", String.class, null);
+        for (int i = 0; i < 10; ++i) {
+            Item item = table.addItem(i);
+            item.getItemProperty("id").setValue(i + " foobar");
+        }
+        return table;
+    }
+
+    private void addContextMenu(TreeTable table) {
+        menu = new ContextMenu(table, true);
+        menu.addItem("foobar", null);
+        menu.addSeparator();
+        menu.addItem("shazbot", null);
+    }
+
+    private void addItemClickListener(TreeTable table) {
+        table.addItemClickListener(event -> {
+            if (event.getButton() == MouseButton.RIGHT) {
+                log(event, "context-click");
+            } else if (event.isDoubleClick()) {
+                log(event, "double-click");
+            } else {
+                log(event, "click!");
+            }
+        });
+    }
+
+    private void log(EventObject event, String message) {
+        logLayout.addComponentAsFirst(
+                new Label(counter++ + event.getClass().getSimpleName() + " "
+                        + event.getSource().getClass().getSimpleName() + " "
+                        + message));
+    }
+}

--- a/vaadin-context-menu-demo/src/main/java/com/vaadin/addon/contextmenu/ContextmenuUI.java
+++ b/vaadin-context-menu-demo/src/main/java/com/vaadin/addon/contextmenu/ContextmenuUI.java
@@ -29,6 +29,14 @@ public class ContextmenuUI extends UI {
 
     @Override
     protected void init(VaadinRequest request) {
+        if (request.getParameter("treetable") != null) {
+            setContent(new ContextMenuTreeTable());
+        } else {
+            initUI();
+        }
+    }
+
+    private void initUI() {
         final VerticalLayout layout = new VerticalLayout();
         layout.setMargin(true);
         setContent(layout);


### PR DESCRIPTION
Workaround for ItemClickListener preventing ContextMenu to open,
because stealing events. Done so that there is no need to change
VScrollTable click behavior.

Fixes #29 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/context-menu/54)
<!-- Reviewable:end -->
