### PR TITLE
Prvents calling handleNavigation twice

### DIFF
--- a/vaadin-context-menu-addon/src/main/java/com/vaadin/contextmenu/client/MyVMenuBar.java
+++ b/vaadin-context-menu-addon/src/main/java/com/vaadin/contextmenu/client/MyVMenuBar.java
@@ -186,7 +186,7 @@ public class MyVMenuBar extends VMenuBar {
                     setSelected(items.get(items.size() - 1));
                 }
 
-                if (!getSelected().isSelectable()) {
+                if (!getSelected().isSelectable() || !getSelected().isEnabled()) {
                     handleNavigation(keycode, ctrl, shift);
                 }
             }
@@ -214,7 +214,7 @@ public class MyVMenuBar extends VMenuBar {
                     setSelected(items.get(0));
                 }
 
-                if (!getSelected().isSelectable()) {
+                if (!getSelected().isSelectable() || !getSelected().isEnabled()) {
                     handleNavigation(keycode, ctrl, shift);
                 }
             }

--- a/vaadin-context-menu-addon/src/main/java/com/vaadin/contextmenu/client/VMenuItem.java
+++ b/vaadin-context-menu-addon/src/main/java/com/vaadin/contextmenu/client/VMenuItem.java
@@ -2,6 +2,7 @@ package com.vaadin.contextmenu.client;
 
 import java.util.logging.Logger;
 
+import com.google.gwt.user.client.Event;
 import com.vaadin.client.ui.VMenuBar.CustomMenuItem;
 
 public class VMenuItem extends CustomMenuItem {
@@ -20,5 +21,10 @@ public class VMenuItem extends CustomMenuItem {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public void onBrowserEvent(Event event) {
+        //Don't do anything. Action is handled by NativeEventPreview in ContextMenuConnector
     }
 }


### PR DESCRIPTION
Override calling onBrowserevent from CustomMenuItem to prevent executing the same action twice. Also, added check to skip the item, if it's disabled.

Fix #89

Also, test case in the current UI is enough to reproduce the problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/context-menu/90)
<!-- Reviewable:end -->
