### PR TITLE
fix: Fix vaadin-server scope

### DIFF
--- a/vaadin-context-menu-addon/pom.xml
+++ b/vaadin-context-menu-addon/pom.xml
@@ -82,6 +82,7 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-server</artifactId>
             <version>${vaadin.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
For convenience, when using ContextMenu with vaadin-server-mpr-jakarta.